### PR TITLE
Errores en el crud de usuarios solucionado.

### DIFF
--- a/app/Http/Livewire/Usuarios.php
+++ b/app/Http/Livewire/Usuarios.php
@@ -42,6 +42,14 @@ class Usuarios extends Component
         ]);
     }
 
+    // Funcion que cierra el modal que edita los usuarios y
+    // resetea el valor de roles para que no interfiera en el create.
+    public function cerrarModalEdit()
+    {
+        $this->reset('roles_seleccionados');
+        $this->openEdit = false;
+    }
+
     public function show(User $user)
     {
         $this->openShow = true;
@@ -79,6 +87,7 @@ class Usuarios extends Component
     public function edit(User $user)
     {
         $this->user = $user;
+        $this->roles_seleccionados = $user->roles()->pluck('id', 'name');
         $this->openEdit = true;
     }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1383,10 +1383,6 @@ select {
   --tw-border-opacity: 1;
   border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
-.border-indigo-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(165 180 252 / var(--tw-border-opacity));
-}
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
@@ -1443,13 +1439,13 @@ select {
   --tw-bg-opacity: 1;
   background-color: rgb(220 252 231 / var(--tw-bg-opacity));
 }
-.bg-red-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
-}
 .bg-blue-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(59 130 246 / var(--tw-bg-opacity));
+}
+.bg-red-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity));
 }
 .bg-opacity-25 {
   --tw-bg-opacity: 0.25;
@@ -1858,6 +1854,10 @@ select {
   --tw-bg-opacity: 1;
   background-color: rgb(21 128 61 / var(--tw-bg-opacity));
 }
+.hover\:bg-blue-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(29 78 216 / var(--tw-bg-opacity));
+}
 .hover\:bg-indigo-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(67 56 202 / var(--tw-bg-opacity));
@@ -1865,10 +1865,6 @@ select {
 .hover\:bg-red-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(185 28 28 / var(--tw-bg-opacity));
-}
-.hover\:bg-blue-700:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(29 78 216 / var(--tw-bg-opacity));
 }
 .hover\:bg-red-400:hover {
   --tw-bg-opacity: 1;

--- a/resources/views/livewire/usuarios/edit.blade.php
+++ b/resources/views/livewire/usuarios/edit.blade.php
@@ -34,9 +34,8 @@
             <x-jet-label value="Roles" />
             <div class="flex">
                 @foreach ($roles as $rol)
-                <x-jet-label value="{{$rol->name}}" class="ml-2 mr-1" />
-                <input wire:model="roles_seleccionados.{{$rol->name}}" value="{{ $rol->name }}" type="checkbox" name="roles_seleccionados" id="roles_seleccionados">
-                        {{--@foreach ($user->roles as $roles2) @if ($roles_seleccionados->contains('name', $roles2->name)) checked @endif @endforeach FUNCIONA, PERO NO APARECEN CHECKED.--}}
+                    <x-jet-label value="{{$rol->name}}" class="ml-2 mr-1" />
+                    <input wire:model="roles_seleccionados.{{$rol->name}}" value="{{ $rol->name }}" type="checkbox" name="roles_seleccionados" id="roles_seleccionados">
                 @endforeach
             </div>
         </div>
@@ -44,7 +43,7 @@
     </x-slot>
 
     <x-slot name="footer">
-        <button wire:click="$set('openEdit', false)" class="p-2 pl-5 pr-5 bg-gray-500 text-gray-100 text-lg rounded-full focus:border-4 border-gray-300">
+        <button wire:click="cerrarModalEdit" class="p-2 pl-5 pr-5 bg-gray-500 text-gray-100 text-lg rounded-full focus:border-4 border-gray-300">
             Cancelar
         </button>
 


### PR DESCRIPTION
Soluciona dos errores en el crud de usuarios:

- Al hacer click en el botón de editar no se veían los checkboxs de roles que el usuario tenia como checked.
- Al hacer click en el boton de editar se veían los checkboxs de roles que tenia el usuario como checked, al cerrar el modal y abrir el modal de crear usuario, se veía el checkbox del rol que en el modal de editar estaba checked como checked en el modal de crear.

Fixes #40 