### PR TITLE
Errores en el crud de roles solucionado.

### DIFF
--- a/app/Http/Livewire/Roles.php
+++ b/app/Http/Livewire/Roles.php
@@ -34,6 +34,14 @@ class Roles extends Component
         ]);
     }
 
+    // Funcion que cierra el modal que edita los usuarios y
+    // resetea el valor de roles para que no interfiera en el create.
+    public function cerrarModalEdit()
+    {
+        $this->reset('permiso_seleccionados');
+        $this->openEdit = false;
+    }
+
     public function save()
     {
 
@@ -60,6 +68,7 @@ class Roles extends Component
     public function edit(Role $rol)
     {
         $this->rol = $rol;
+        $this->permiso_seleccionados = $rol->permissions()->pluck('id', 'name');
         $this->openEdit = true;
     }
 

--- a/resources/views/livewire/roles/edit.blade.php
+++ b/resources/views/livewire/roles/edit.blade.php
@@ -16,9 +16,8 @@
             <x-jet-label value="Permisos" />
             <div class="flex">
                 @foreach ($permisos as $permiso)
-                <x-jet-label value="{{$permiso->name}}" class="ml-2 mr-1" />
-                <input wire:model="permiso_seleccionados.{{$permiso->name}}" value="{{ $permiso->name }}" type="checkbox" name="permiso_seleccionados" id="permiso_seleccionados">
-                       {{--@foreach ($user->roles as $roles2) @if ($roles_seleccionados->contains('name', $roles2->name)) checked @endif @endforeach FUNCIONA, PERO NO APARECEN CHECKED.--}}
+                    <x-jet-label value="{{$permiso->name}}" class="ml-2 mr-1" />
+                    <input wire:model="permiso_seleccionados.{{$permiso->name}}" value="{{ $permiso->name }}" type="checkbox" name="permiso_seleccionados" id="permiso_seleccionados">
                 @endforeach
             </div>
         </div>
@@ -27,7 +26,7 @@
     </x-slot>
 
     <x-slot name="footer">
-        <button wire:click="$set('openEdit', false)" class="p-2 pl-5 pr-5 bg-gray-500 text-gray-100 rounded-full text-lg  focus:border-4 border-gray-300">
+        <button wire:click="cerrarModalEdit" class="p-2 pl-5 pr-5 bg-gray-500 text-gray-100 rounded-full text-lg  focus:border-4 border-gray-300">
             Cancelar
         </button>
 


### PR DESCRIPTION
Soluciona dos errores en el crud de usuarios:

- Al hacer click en el botón de editar no se veían los checkboxs de permisos que el rol tenia como checked.
- Al hacer click en el boton de editar se veían los checkboxs de permisos que tenia el rol como checked, al cerrar el modal y abrir el modal de crear rol, se veía el checkbox del permiso que en el modal de editar estaba checked como checked en el modal de crear.

Fixes #65 